### PR TITLE
Return response to user when get error from CoC API

### DIFF
--- a/index.js
+++ b/index.js
@@ -620,6 +620,9 @@ DiscordClient.on('message', message => {
             message.channel.send('Please provide a valid player tag to look up. Valid tag characters are: \n```\n0289PYLQGRJCUV\n```')
           } else if (data && !data.hasOwnProperty('reason')) {
             playerReport(message.channel, data)
+          } else {
+            message.channel.send('Got an error trying to get the player data')
+            // TODO: include the error code and reason in the returned response to the user for easier troubleshooting
           }
         })
       } else {


### PR DESCRIPTION
In case when CoC API returns an error code (and a 'reason') it should also be returned to the user that something went wrong.
Better if can include the error code and actual response from the API.